### PR TITLE
Replace quadratic `rankify` function by n lg n implementation

### DIFF
--- a/tests/util/test_spearman.cpp
+++ b/tests/util/test_spearman.cpp
@@ -93,8 +93,8 @@ TEST(Spearman, AllIdentical) {
 }
 
 TEST(Spearman, SomeValues) {
-    std::vector<double> a = {35, 23, 47, 17, 10, 43, 9, 6, 28};
-    std::vector<double> b = {30, 33, 45, 23, 8, 49, 12, 4, 31};
+    std::vector<double> a = { 35, 23, 47, 17, 10, 43, 9, 6, 28 };
+    std::vector<double> b = { 30, 33, 45, 23, 8, 49, 12, 4, 31 };
     ASSERT_EQ(0.9, spearman(a, b));
 }
 
@@ -118,9 +118,16 @@ TEST(Spearman, LinearRepeats) {
     }
 }
 
+TEST(Spearman, Rankify) {
+    std::vector<double> a = { 1, 1, 2, 2, 3, 3, 4, 5, 5 };
+    std::vector<double> expected_ranks { 1.5, 1.5, 3.5, 3.5, 5.5, 5.5, 7, 8.5, 8.5 };
+    ASSERT_EQ(expected_ranks, rankify(a));
+}
+
 TEST(Spearman, SomeValuesRepeats) {
-    std::vector<double> a = {1,1,2,2,3,3,4,5,5};
-    std::vector<double> b = {7,8,8,19,19,3,3,5,9};
+    std::vector<double> a = { 1, 1, 2, 2, 3, 3, 4, 5, 5 };
+    std::vector<double> b = { 7, 8, 8, 19, 19, 3, 3, 5, 9 };
+
     ASSERT_NEAR(-0.19314, spearman(a, b), 1e-5);
 }
 

--- a/util/spearman.hpp
+++ b/util/spearman.hpp
@@ -5,22 +5,20 @@
 #include <cmath>
 using namespace std;
 
-// Function returns the rank vector of a set of observations v
+// Function returns the 1-based rank vector of a set of observations v
 template <typename T>
-std::vector<double> rankify(std::vector<T> &v) {
+std::vector<double> rankify(const std::vector<T> &v) {
+    std::vector<T> sorted = v;
+    std::sort(begin(sorted), end(sorted));
+
     std::vector<double> result(v.size());
 
     for (size_t i = 0; i < v.size(); i++) {
-        size_t r = 1, s = 1;
+        const auto lb = std::lower_bound(std::begin(sorted), std::end(sorted), v[i]);
+        const auto ub = std::upper_bound(std::begin(sorted), std::end(sorted), v[i]);
+        const size_t r = 1 + (lb - std::begin(sorted)), s = ub - lb;
 
-        for (size_t j = 0; j < v.size(); j++) {
-            if (v[j] < v[i])
-                r++;
-            if (v[j] == v[i])
-                s++;
-        }
-
-        // Use Fractional Rank formula fractional_rank = r + (n-1)/2
+        // Use Fractional Rank formula fractional_rank = r + (s-1)/2
         result[i] = r + (s - 1) * 0.5;
     }
 
@@ -29,7 +27,7 @@ std::vector<double> rankify(std::vector<T> &v) {
 
 /* Compute the Pearson correlation coefficient of a and b */
 template <typename T>
-double pearson(std::vector<T> &a, std::vector<T> &b) {
+double pearson(const std::vector<T> &a, const std::vector<T> &b) {
     assert(a.size() == b.size());
     T sum_a = 0, sum_b = 0, sum_ab = 0;
     T square_sum_a = 0, square_sum_b = 0;
@@ -57,7 +55,7 @@ double pearson(std::vector<T> &a, std::vector<T> &b) {
 }
 
 template <typename T>
-double spearman(std::vector<T> &a, std::vector<T> &b) {
+double spearman(const std::vector<T> &a, const std::vector<T> &b) {
     std::vector<double> rank1 = rankify(a);
     std::vector<double> rank2 = rankify(b);
     return pearson(rank1, rank2);


### PR DESCRIPTION
This significantly speeds up the computation of the Spearman coefficient, already with `binom(200, 2)` distances.

Also adds some more `const` and auto-formatting.