### PR TITLE
Hashbase cleanup

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -73,7 +73,7 @@ RawStringFormats:
     Language:        TextProto
     BasedOnStyle:    LLVM
 ReflowComments: true
-SortIncludes: false
+SortIncludes: true
 SortUsingDeclarations: false
 SpaceAfterCStyleCast: false
 SpaceAfterTemplateKeyword: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 cmake-build-debug
 cmake-build-release
 .idea
+build
+compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.13)
 project(sequence_sketching)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 find_package(OpenMP REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,15 +20,19 @@ file(GLOB sequence_files "sequence/*.cpp")
 add_library(sequence ${sequence_files})
 target_link_libraries(sequence gflags OpenMP::OpenMP_CXX)
 
+file(GLOB sketch_files "sketch/*.cpp")
+add_library(sketch_lib ${sketch_files})
+target_link_libraries(sketch_lib OpenMP::OpenMP_CXX)
+
 
 add_executable(experiments experiments_main.cpp )
-target_link_libraries(experiments sequence util)
+target_link_libraries(experiments sequence util sketch_lib)
 
 add_executable(sketch sketch_main.cpp)
-target_link_libraries(sketch sequence util)
+target_link_libraries(sketch sequence util sketch_lib)
 
 add_executable(seqgen sequence_generator_main.cpp)
-target_link_libraries(seqgen sequence util)
+target_link_libraries(seqgen sequence util sketch_lib)
 
 # TESTS
 string(APPEND CMAKE_CXX_FLAGS " -Wall -Wextra -Werror  -msse4")
@@ -44,7 +48,7 @@ target_compile_options(gtest PRIVATE -w)
 file(GLOB test_files "tests/**/*.cpp")
 
 add_executable(tests ${test_files})
-target_link_libraries(tests gtest_main gtest gmock util)
+target_link_libraries(tests gtest_main gtest gmock util sketch_lib)
 target_include_directories(tests PRIVATE "include")
 
 gtest_discover_tests(tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.13)
 project(sequence_sketching)
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 find_package(OpenMP REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
 project(sequence_sketching)
 set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 find_package(OpenMP REQUIRED)
 
 include_directories(.)

--- a/experiments_main.cpp
+++ b/experiments_main.cpp
@@ -14,10 +14,11 @@
 #include "util/transformer.hpp"
 #include "util/utils.hpp"
 
+#include <gflags/gflags.h>
+
 #include <filesystem>
 #include <memory>
 #include <omp.h>
-
 
 DEFINE_uint32(kmer_size, 4, "Kmer size for MH, OMH, WMH");
 

--- a/sketch/dim_reduce.h
+++ b/sketch/dim_reduce.h
@@ -3,6 +3,7 @@
 #include "util/utils.hpp"
 
 #include <cstddef>
+#include <random>
 #include <vector>
 
 
@@ -50,7 +51,7 @@ class Int32Flattener {
         std::vector<double> d(v1.size());
         double val = 0;
         for (size_t i = 0; i < d.size(); i++) {
-            val += std::__popcount(v1[i] ^ v2[i]);
+            val += __builtin_popcount(v1[i] ^ v2[i]);
         }
         return val;
     }

--- a/sketch/hash_base.cpp
+++ b/sketch/hash_base.cpp
@@ -1,0 +1,15 @@
+#include "sketch/hash_base.hpp"
+
+namespace ts {
+
+HashAlgorithm parse_hash_algorithm(const std::string &name) {
+    if (name == "uniform") {
+        return HashAlgorithm::uniform;
+    }
+    if (name == "crc32") {
+        return HashAlgorithm::crc32;
+    }
+    assert(false);
+}
+
+} // namespace ts

--- a/sketch/hash_base.hpp
+++ b/sketch/hash_base.hpp
@@ -36,8 +36,8 @@ class HashBase {
 
   protected:
     T set_size;
-    size_t sketch_dim {};
-    size_t hash_size {};
+    size_t sketch_dim;
+    size_t hash_size;
 
     /**
      * Returns the hash value for the index-th hash function.

--- a/sketch/hash_min.hpp
+++ b/sketch/hash_min.hpp
@@ -22,14 +22,13 @@ namespace ts { // ts = Tensor Sketch
 template <class T>
 class MinHash : public HashBase<T> {
   public:
-    MinHash() {}
     /**
      * Constructs a min-hasher for the given alphabet size which constructs sketches of the set size
      * and sketch dimension.
      * @param set_size the number of elements in S,
      * @param sketch_dim the number of components (elements) in the sketch vector.
      */
-    MinHash(T set_size, size_t sketch_dim, std::string hash_algorithm)
+    MinHash(T set_size, size_t sketch_dim, HashAlgorithm hash_algorithm)
         : HashBase<T>(set_size, sketch_dim, set_size, hash_algorithm) {}
 
     /**

--- a/sketch/hash_ordered.hpp
+++ b/sketch/hash_ordered.hpp
@@ -18,7 +18,6 @@ namespace ts { // ts = Tensor Sketch
 template <class T>
 class OrderedMinHash : public HashBase<T> {
   public:
-    OrderedMinHash() {}
     /**
      * @param set_size the number of elements in S
      * @param sketch_dim the number of components (elements) in the sketch vector.
@@ -29,7 +28,7 @@ class OrderedMinHash : public HashBase<T> {
                    size_t sketch_dim,
                    size_t max_len,
                    size_t tup_len,
-                   std::string hash_algorithm)
+                   HashAlgorithm hash_algorithm)
         : HashBase<T>(set_size, sketch_dim, set_size * max_len, hash_algorithm),
           max_len(max_len),
           tup_len(tup_len) {}

--- a/sketch/hash_weighted.hpp
+++ b/sketch/hash_weighted.hpp
@@ -25,8 +25,6 @@ namespace ts { // ts = Tensor Sketch
 template <class T>
 class WeightedMinHash : public HashBase<T> {
   public:
-    WeightedMinHash() {}
-
     /**
      * Constructs a weighted min-hasher for the given alphabet size which constructs sketches of the
      * given set size, dimension and maximum length.
@@ -34,7 +32,7 @@ class WeightedMinHash : public HashBase<T> {
      * @param sketch_dim the number of components (elements) in the sketch vector.
      * @param max_len maximum sequence length to be hashed.
      */
-    WeightedMinHash(T set_size, size_t sketch_dim, size_t max_len, std::string hash_algorithm)
+    WeightedMinHash(T set_size, size_t sketch_dim, size_t max_len, HashAlgorithm hash_algorithm)
         : HashBase<T>(set_size, sketch_dim, max_len * set_size, hash_algorithm), max_len(max_len) {}
 
     std::vector<T> compute(const std::vector<T> &kmers) {

--- a/sketch_main.cpp
+++ b/sketch_main.cpp
@@ -1,5 +1,6 @@
 #include "sequence/fasta_io.hpp"
 
+#include "sketch/hash_base.hpp"
 #include "sketch/hash_min.hpp"
 #include "sketch/hash_ordered.hpp"
 #include "sketch/hash_weighted.hpp"
@@ -175,22 +176,26 @@ int main(int argc, char *argv[]) {
 
     if (FLAGS_sketch_method.substr(FLAGS_sketch_method.size() - 2, 2) == "MH") {
         std::function<std::vector<uint64_t>(const std::vector<uint64_t> &)> sketcher;
-        MinHash<uint64_t> min_hash;
-        WeightedMinHash<uint64_t> wmin_hash;
-        OrderedMinHash<uint64_t> omin_hash;
 
         if (FLAGS_sketch_method == "MH") {
-            min_hash = MinHash<uint64_t>(kmer_word_size, FLAGS_embed_dim, "uniform");
-            sketcher = [&](const std::vector<uint64_t> &seq) { return min_hash.compute(seq); };
+            sketcher = [&](const std::vector<uint64_t> &seq) {
+                MinHash<uint64_t> min_hash(kmer_word_size, FLAGS_embed_dim, HashAlgorithm::uniform);
+                return min_hash.compute(seq);
+            };
         } else if (FLAGS_sketch_method == "WMH") {
-            wmin_hash = WeightedMinHash<uint64_t>(kmer_word_size, FLAGS_embed_dim, FLAGS_max_len,
-                                                  "uniform");
-            sketcher = [&](const std::vector<uint64_t> &seq) { return wmin_hash.compute(seq); };
+            sketcher = [&](const std::vector<uint64_t> &seq) {
+                WeightedMinHash<uint64_t> wmin_hash(kmer_word_size, FLAGS_embed_dim, FLAGS_max_len,
+                                                    HashAlgorithm::uniform);
+
+                return wmin_hash.compute(seq);
+            };
         } else if (FLAGS_sketch_method == "OMH") {
-            omin_hash = OrderedMinHash<uint64_t>(kmer_word_size, FLAGS_embed_dim, FLAGS_max_len,
-                                                 FLAGS_tuple_length, "uniform");
-            sketcher
-                    = [&](const std::vector<uint64_t> &seq) { return omin_hash.compute_flat(seq); };
+            sketcher = [&](const std::vector<uint64_t> &seq) {
+                OrderedMinHash<uint64_t> omin_hash(kmer_word_size, FLAGS_embed_dim, FLAGS_max_len,
+                                                   FLAGS_tuple_length, HashAlgorithm::uniform);
+
+                return omin_hash.compute_flat(seq);
+            };
         }
         std::function<Vec2D<double>(const std::vector<uint64_t> &)> slide_sketcher
                 = [&](const std::vector<uint64_t> &) { return new2D<double>(0, 0); };

--- a/sketch_main.cpp
+++ b/sketch_main.cpp
@@ -1,14 +1,14 @@
 #include "sequence/fasta_io.hpp"
-
 #include "sketch/hash_base.hpp"
 #include "sketch/hash_min.hpp"
 #include "sketch/hash_ordered.hpp"
 #include "sketch/hash_weighted.hpp"
 #include "sketch/tensor.hpp"
 #include "sketch/tensor_slide.hpp"
-
 #include "util/multivec.hpp"
 #include "util/utils.hpp"
+
+#include <gflags/gflags.h>
 
 #include <filesystem>
 #include <memory>

--- a/tests/sketch/test_hash_base.cpp
+++ b/tests/sketch/test_hash_base.cpp
@@ -18,7 +18,7 @@ constexpr uint8_t HASH_SIZE = MAX_LEN * SET_SIZE;
 
 class Hash : public HashBase<uint8_t>, public testing::Test {
   public:
-    Hash() : HashBase<uint8_t>(SET_SIZE, SKETCH_DIM, HASH_SIZE, "uniform") {}
+    Hash() : HashBase<uint8_t>(SET_SIZE, SKETCH_DIM, HASH_SIZE, HashAlgorithm::uniform) {}
 };
 
 // test that the hash function bijective, i.e. it is in effect a permutation:

--- a/tests/sketch/test_min_hash.cpp
+++ b/tests/sketch/test_min_hash.cpp
@@ -1,3 +1,4 @@
+#include "sketch/hash_base.hpp"
 #include "sketch/hash_min.hpp"
 
 #include <gtest/gtest.h>
@@ -11,13 +12,13 @@ using namespace ts;
 using namespace ::testing;
 
 TEST(MinHash, Empty) {
-    MinHash<uint8_t> under_test(4 * 4 * 4, 3, "uniform");
+    MinHash<uint8_t> under_test(4 * 4 * 4, 3, HashAlgorithm::uniform);
     std::vector<uint8_t> sketch = under_test.compute(std::vector<uint8_t>());
     ASSERT_THAT(sketch, ElementsAre(0, 0, 0));
 }
 
 TEST(MinHash, Repeat) {
-    MinHash<uint8_t> under_test(4 * 4 * 4, 3, "uniform");
+    MinHash<uint8_t> under_test(4 * 4 * 4, 3, HashAlgorithm::uniform);
     std::vector<uint8_t> sequence = { 0, 1, 2, 3, 4, 5 };
     std::vector<uint8_t> sketch1 = under_test.compute(sequence);
     std::vector<uint8_t> sketch2 = under_test.compute(sequence);
@@ -25,7 +26,7 @@ TEST(MinHash, Repeat) {
 }
 
 TEST(MinHash, Permute) {
-    MinHash<uint8_t> under_test(4 * 4 * 4, 3, "uniform");
+    MinHash<uint8_t> under_test(4 * 4 * 4, 3, HashAlgorithm::uniform);
     std::vector<uint8_t> sequence1 = { 0, 1, 2, 3, 4, 5 };
     std::vector<uint8_t> sequence2 = { 5, 4, 3, 2, 1, 0 };
     std::vector<uint8_t> sketch1 = under_test.compute(sequence1);
@@ -34,7 +35,7 @@ TEST(MinHash, Permute) {
 }
 
 TEST(MinHash, PermuteAndRepeat) {
-    MinHash<uint8_t> under_test(4 * 4 * 4, 3, "uniform");
+    MinHash<uint8_t> under_test(4 * 4 * 4, 3, HashAlgorithm::uniform);
     std::vector<uint8_t> sequence1 = { 0, 1, 2, 3, 4, 5 };
     std::vector<uint8_t> sequence2 = { 5, 5, 4, 4, 3, 3, 2, 2, 1, 1, 0, 0 };
     std::vector<uint8_t> sketch1 = under_test.compute(sequence1);
@@ -53,7 +54,7 @@ std::vector<std::unordered_map<uint8_t, uint8_t>> hash_init(uint32_t set_sz, uin
 }
 
 TEST(MinHash, PresetHash) {
-    MinHash<uint8_t> under_test(4 * 4, 3, "uniform");
+    MinHash<uint8_t> under_test(4 * 4, 3, HashAlgorithm::uniform);
     under_test.set_hashes_for_testing(hash_init(4 * 4, 3));
     for (uint32_t i = 0; i < 4 * 4; ++i) {
         std::vector<uint8_t> sequence(4 * 4 - i);

--- a/tests/sketch/test_ordered_min_hash.cpp
+++ b/tests/sketch/test_ordered_min_hash.cpp
@@ -18,13 +18,13 @@ constexpr uint32_t max_sequence_len = 200;
 
 TEST(OrderedMinHash, Empty) {
     OrderedMinHash<uint8_t> under_test(set_size, sketch_dim, max_sequence_len, tuple_length,
-                                       "uniform");
+                                       HashAlgorithm::uniform);
     ASSERT_THROW(under_test.compute(std::vector<uint8_t>()), std::invalid_argument);
 }
 
 TEST(OrderedMinHash, Repeat) {
     OrderedMinHash<uint8_t> under_test(set_size, sketch_dim, max_sequence_len, tuple_length,
-                                       "uniform");
+                                       HashAlgorithm::uniform);
     std::vector<uint8_t> sequence = { 0, 1, 2, 3, 4, 5 };
     Vec2D<uint8_t> sketch1 = under_test.compute(sequence);
     Vec2D<uint8_t> sketch2 = under_test.compute(sequence);
@@ -37,7 +37,7 @@ TEST(OrderedMinHash, Repeat) {
 
 TEST(OrderedMinHash, Permute) {
     OrderedMinHash<uint8_t> under_test(set_size, sketch_dim, max_sequence_len, tuple_length,
-                                       "uniform");
+                                       HashAlgorithm::uniform);
     std::vector<uint8_t> sequence1 = { 0, 1, 2, 3, 4, 5 };
     std::vector<uint8_t> sequence2 = { 5, 4, 3, 2, 1, 0 };
     Vec2D<uint8_t> sketch1 = under_test.compute(sequence1);
@@ -62,7 +62,7 @@ hash_init(uint32_t set_sz, uint32_t sketch_size, uint32_t max_seq_len) {
 
 TEST(OrderedMinHash, PresetHash) {
     OrderedMinHash<uint8_t> under_test(set_size, sketch_dim, max_sequence_len, tuple_length,
-                                       "uniform");
+                                       HashAlgorithm::uniform);
     under_test.set_hashes_for_testing(hash_init(set_size, sketch_dim, max_sequence_len));
     for (uint32_t i = 0; i < set_size - tuple_length; ++i) {
         std::vector<uint8_t> sequence(set_size - i);
@@ -76,7 +76,7 @@ TEST(OrderedMinHash, PresetHash) {
 
 TEST(OrderedMinHash, PresetHashRepeat) {
     OrderedMinHash<uint8_t> under_test(set_size, sketch_dim, max_sequence_len, tuple_length,
-                                       "uniform");
+                                       HashAlgorithm::uniform);
     under_test.set_hashes_for_testing(hash_init(set_size, sketch_dim, max_sequence_len));
     for (uint32_t i = 0; i < set_size - tuple_length; ++i) {
         std::vector<uint8_t> sequence(2 * (set_size - i));
@@ -92,7 +92,7 @@ TEST(OrderedMinHash, PresetHashRepeat) {
 #ifndef NDEBUG
 TEST(OrderedMinhash, SequenceTooLong) {
     OrderedMinHash<uint8_t> under_test(set_size, sketch_dim, max_sequence_len, tuple_length,
-                                       "uniform");
+                                       HashAlgorithm::uniform);
     std::vector<uint8_t> sequence(max_sequence_len + 1);
     ASSERT_THROW(under_test.compute(sequence), std::invalid_argument);
 }

--- a/tests/sketch/test_weighted_min_hash.cpp
+++ b/tests/sketch/test_weighted_min_hash.cpp
@@ -12,13 +12,13 @@ using namespace ts;
 using namespace ::testing;
 
 TEST(WeightedMinHash, Empty) {
-    WeightedMinHash<uint8_t> under_test(4 * 4 * 4, 3, 100, "uniform");
+    WeightedMinHash<uint8_t> under_test(4 * 4 * 4, 3, 100, HashAlgorithm::uniform);
     std::vector<uint8_t> sketch = under_test.compute(std::vector<uint8_t>());
     ASSERT_THAT(sketch, ElementsAre(0, 0, 0));
 }
 
 TEST(WeightedMinHash, Repeat) {
-    WeightedMinHash<uint8_t> under_test(4 * 4 * 4, 3, 100, "uniform");
+    WeightedMinHash<uint8_t> under_test(4 * 4 * 4, 3, 100, HashAlgorithm::uniform);
     std::vector<uint8_t> sequence = { 0, 1, 2, 3, 4, 5 };
     std::vector<uint8_t> sketch1 = under_test.compute(sequence);
     std::vector<uint8_t> sketch2 = under_test.compute(sequence);
@@ -26,7 +26,7 @@ TEST(WeightedMinHash, Repeat) {
 }
 
 TEST(WeightedMinHash, Permute) {
-    WeightedMinHash<uint8_t> under_test(4 * 4 * 4, 3, 100, "uniform");
+    WeightedMinHash<uint8_t> under_test(4 * 4 * 4, 3, 100, HashAlgorithm::uniform);
     std::vector<uint8_t> sequence1 = { 0, 1, 2, 3, 4, 5 };
     std::vector<uint8_t> sequence2 = { 5, 4, 3, 2, 1, 0 };
     std::vector<uint8_t> sketch1 = under_test.compute(sequence1);
@@ -46,7 +46,7 @@ hash_init(uint32_t set_sz, uint32_t sketch_size, uint32_t max_seq_len) {
 }
 
 TEST(WeightedMinHash, PresetHash) {
-    WeightedMinHash<uint8_t> under_test(4 * 4, 3, 100, "uniform");
+    WeightedMinHash<uint8_t> under_test(4 * 4, 3, 100, HashAlgorithm::uniform);
     under_test.set_hashes_for_testing(hash_init(4 * 4, 3, 100));
     for (uint32_t i = 0; i < 4 * 4; ++i) {
         std::vector<uint8_t> sequence(4 * 4 - i);
@@ -58,7 +58,7 @@ TEST(WeightedMinHash, PresetHash) {
 
 TEST(WeightedMinHash, PresetHashRepeat) {
     constexpr uint32_t set_size = 4 * 4; // corresponds to k-mers of length 2 over the DNA alphabet
-    WeightedMinHash<uint8_t> under_test(set_size, 3, 100, "uniform");
+    WeightedMinHash<uint8_t> under_test(set_size, 3, 100, HashAlgorithm::uniform);
     under_test.set_hashes_for_testing(hash_init(set_size, 3, 100));
     for (uint32_t i = 0; i < set_size; ++i) {
         std::vector<uint8_t> sequence(2 * (set_size - i));
@@ -72,7 +72,7 @@ TEST(WeightedMinHash, PresetHashRepeat) {
 #ifndef NDEBUG
 TEST(WeightedMinhash, SequenceTooLong) {
     constexpr uint32_t set_size = 4 * 4; // corresponds to k-mers of length 2 over the DNA alphabet
-    WeightedMinHash<uint8_t> under_test(set_size, 3, 100, "uniform");
+    WeightedMinHash<uint8_t> under_test(set_size, 3, 100, HashAlgorithm::uniform);
     std::vector<uint8_t> sequence(100 + 1);
     ASSERT_THROW(under_test.compute(sequence), std::invalid_argument);
 }

--- a/util/spearman.hpp
+++ b/util/spearman.hpp
@@ -1,9 +1,9 @@
 #include <algorithm>
+#include <cassert>
+#include <cmath>
 #include <iostream>
 #include <vector>
 
-#include <cassert>
-#include <cmath>
 using namespace std;
 
 // Function returns the 1-based rank vector of a set of observations v

--- a/util/utils.cpp
+++ b/util/utils.cpp
@@ -1,5 +1,7 @@
 #include "utils.hpp"
 
+#include <gflags/gflags.h>
+
 namespace ts {
 
 std::string flag_values(char delimiter, bool skip_empty) {

--- a/util/utils.hpp
+++ b/util/utils.hpp
@@ -7,9 +7,9 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cmath>
 #include <numeric>
 #include <vector>
-#include <cmath>
 
 namespace ts { // ts = Tensor Sketch
 
@@ -78,7 +78,7 @@ T l1_dist2D_minlen(const Vec2D<T> &a, const Vec2D<T> &b) {
     T val = 0;
     for (size_t i = 0; i < len; i++) {
         for (size_t j = 0; j < a[i].size() and j < b[i].size(); j++) {
-            auto el  = std::abs(a[i][j] - b[i][j]);
+            auto el = std::abs(a[i][j] - b[i][j]);
             val += el;
         }
     }

--- a/util/utils.hpp
+++ b/util/utils.hpp
@@ -3,8 +3,6 @@
 #include "util/multivec.hpp"
 #include "util/timer.hpp"
 
-#include <gflags/gflags.h>
-
 #include <algorithm>
 #include <cassert>
 #include <cmath>


### PR DESCRIPTION
- `hash_algorithm` is now always passed as enum
- this needed a new `hash_base.cpp` with corresponding libraries in the `CMakeLists`
- Removed the default constructor, as the object shouldn't really be in that state anyway. This forces some changes elsewhere to not default initialize the hash objects and only create them when needed. (It's not super pretty, but it'll change again in a followup PR.)

- Also changed the `.clang-format` to sort includes.