### PR TITLE
Unify interface to sketch algorithms

### DIFF
--- a/.hgignore
+++ b/.hgignore
@@ -1,0 +1,1 @@
+third_party

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,8 @@ find_package(OpenMP REQUIRED)
 
 include_directories(.)
 
-set(CMAKE_CXX_FLAGS_DEBUG "-g -Wfatal-errors")
-set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Wfatal-errors")
+set(CMAKE_CXX_FLAGS_DEBUG "-g")
+set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 
 # Google Flags Library
 add_subdirectory(${PROJECT_SOURCE_DIR}/third_party/gflags EXCLUDE_FROM_ALL)
@@ -35,7 +35,7 @@ add_executable(seqgen sequence_generator_main.cpp)
 target_link_libraries(seqgen sequence util sketch_lib)
 
 # TESTS
-string(APPEND CMAKE_CXX_FLAGS " -Wall -Wextra -Werror  -msse4")
+string(APPEND CMAKE_CXX_FLAGS " -Wall -Wextra -Werror -Wfatal-errors -msse4")
 
 
 enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,8 @@ find_package(OpenMP REQUIRED)
 
 include_directories(.)
 
-set(CMAKE_CXX_FLAGS_DEBUG "-g ")
-set(CMAKE_CXX_FLAGS_RELEASE "-O3 ")
+set(CMAKE_CXX_FLAGS_DEBUG "-g -Wfatal-errors")
+set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Wfatal-errors")
 
 # Google Flags Library
 add_subdirectory(${PROJECT_SOURCE_DIR}/third_party/gflags EXCLUDE_FROM_ALL)

--- a/experiments_flags
+++ b/experiments_flags
@@ -1,6 +1,6 @@
 # sequence generation
 --alphabet_size=4
---seq_len=1000
+--seq_len=10000
 --num_seqs=200
 --group_size=2
 --phylogeny_shape=path
@@ -18,7 +18,7 @@
 --window_size=500
 --stride=32
 --max_len=1000
---hash_alg=uniform
+--hash_alg=crc32
 --transform=none
 --num_bins=256
 # execution & I/O

--- a/experiments_flags
+++ b/experiments_flags
@@ -1,6 +1,6 @@
 # sequence generation
 --alphabet_size=4
---seq_len=10000
+--seq_len=1000
 --num_seqs=200
 --group_size=2
 --phylogeny_shape=path
@@ -18,7 +18,7 @@
 --window_size=500
 --stride=32
 --max_len=1000
---hash_alg=crc32
+--hash_alg=uniform
 --transform=none
 --num_bins=256
 # execution & I/O

--- a/experiments_main.cpp
+++ b/experiments_main.cpp
@@ -175,7 +175,7 @@ class ExperimentRunner {
 
             apply_tuple(
                     [&](auto &sketch, auto &alg) {
-                        if constexpr (alg.kmer_input) {
+                        if constexpr (std::remove_reference_t<decltype(alg)>::kmer_input) {
                             sketch[si] = alg.compute(kmer_seq);
                         } else {
                             sketch[si] = alg.compute(seqs[si]);

--- a/experiments_main.cpp
+++ b/experiments_main.cpp
@@ -124,7 +124,8 @@ class ExperimentRunner {
     DoubleFlattener l1Sketch;
 
     std::vector<embed_type> edit_dists;
-    using Distances = std::tuple<std::conditional_t<true, std::vector<double>, SketchAlgorithms>...>;
+    using Distances
+            = std::tuple<std::conditional_t<true, std::vector<double>, SketchAlgorithms>...>;
     Distances dists;
 
     std::vector<std::pair<uint32_t, uint32_t>> ingroup_pairs;
@@ -251,10 +252,8 @@ class ExperimentRunner {
 
         std::vector<std::string> method_names = { "ED", "MH", "WMH", "OMH", "TS", "TSS", "TSS2" };
         fo.open(output_dir / "dists.csv");
-        fo << "s1,s2";
-        for (auto &method_name : method_names) { // table header
-            fo << "," << method_name;
-        }
+        fo << "s1,s2,ED";
+        apply_tuple([&](const auto &algo) { fo << "," << algo.name; }, algorithms_);
         fo << "\n";
         for (uint32_t pi = 0; pi < ingroup_pairs.size(); pi++) {
             fo << ingroup_pairs[pi].first << "," << ingroup_pairs[pi].second; // seq 1 & 2 indices
@@ -285,16 +284,14 @@ int main(int argc, char *argv[]) {
     using kmer_type = uint64_t;
     using embed_type = double;
     auto experiment = MakeExperimentRunner<char_type, kmer_type, embed_type>(
-            MinHash<kmer_type>(int_pow<uint32_t>(FLAGS_alphabet_size, FLAGS_kmer_size), FLAGS_embed_dim,
-                               parse_hash_algorithm(FLAGS_hash_alg), "MH"),
+            MinHash<kmer_type>(int_pow<uint32_t>(FLAGS_alphabet_size, FLAGS_kmer_size),
+                               FLAGS_embed_dim, parse_hash_algorithm(FLAGS_hash_alg), "MH"),
             WeightedMinHash<kmer_type>(int_pow<uint32_t>(FLAGS_alphabet_size, FLAGS_kmer_size),
-                                       FLAGS_embed_dim,
-                                       FLAGS_max_len, parse_hash_algorithm(FLAGS_hash_alg),
-                                       "WMH"),
+                                       FLAGS_embed_dim, FLAGS_max_len,
+                                       parse_hash_algorithm(FLAGS_hash_alg), "WMH"),
             OrderedMinHash<kmer_type>(int_pow<uint32_t>(FLAGS_alphabet_size, FLAGS_kmer_size),
-                                      FLAGS_embed_dim,
-                                      FLAGS_max_len, FLAGS_tuple_length, parse_hash_algorithm(FLAGS_hash_alg),
-                                      "OMH")
+                                      FLAGS_embed_dim, FLAGS_max_len, FLAGS_tuple_length,
+                                      parse_hash_algorithm(FLAGS_hash_alg), "OMH")
             // Tensor<char_type>(FLAGS_alphabet_size, FLAGS_embed_dim, FLAGS_tuple_length),
             // TensorSlide<char_type>(FLAGS_alphabet_size, ceil(sqrt(FLAGS_embed_dim)),
             // FLAGS_tuple_length, FLAGS_window_size, FLAGS_stride)

--- a/experiments_main.cpp
+++ b/experiments_main.cpp
@@ -152,7 +152,18 @@ class ExperimentRunner {
         }
         std::cout << std::endl;
 
-        // TODO: Transform sketches???
+        // If needed, transform the sketch output.
+        // Currently this is only done for TensorSketch variants when the command line flag is set.
+        if constexpr (SketchAlgorithm::transform_sketches) {
+            if (FLAGS_transform == "disc") {
+                discretize<double> disc(FLAGS_num_bins);
+                apply(sketch, disc);
+            } else if (FLAGS_transform == "atan") {
+                atan_scaler<double> atan;
+                apply(sketch, atan);
+            }
+        }
+
 
         // Compute pairwise distances.
         std::cout << "Compute distances ... " << std::endl;
@@ -209,22 +220,6 @@ class ExperimentRunner {
         }
         std::cout << endl;
     }
-
-    /*
-    void transform_sketches() {
-        // TODO: Why do we need/want this?
-        if (FLAGS_transform == "disc") {
-            discretize<double> disc(FLAGS_num_bins);
-            apply2D(ts_sketch, disc);
-            apply3D(tss_sketch, disc);
-        } else if (FLAGS_transform == "atan") {
-            atan_scaler<double> atan;
-            apply2D(ts_sketch, atan);
-            apply3D(tss_sketch, atan);
-        }
-    }
-    */
-
 
     void save_output() {
         const std::filesystem::path output_dir(FLAGS_o);

--- a/sketch/dim_reduce.h
+++ b/sketch/dim_reduce.h
@@ -11,7 +11,7 @@ namespace ts {
 
 class Int32Flattener {
   public:
-    Int32Flattener() {}
+    using sketch_type = std::vector<uint32_t>;
 
     Int32Flattener(uint32_t flat_dim, uint32_t sketch_dim, uint32_t max_len)
         : flat_dim(flat_dim), sketch_dim(sketch_dim), max_len(max_len) {
@@ -66,7 +66,7 @@ class Int32Flattener {
 
 class DoubleFlattener {
   public:
-    DoubleFlattener() {}
+    using sketch_type = std::vector<double>;
 
     DoubleFlattener(uint32_t output_dim, uint32_t input_dim, uint32_t input_max_len)
         : flat_dim(output_dim), sketch_dim(input_dim), max_len(input_max_len) {

--- a/sketch/hash_base.hpp
+++ b/sketch/hash_base.hpp
@@ -23,7 +23,7 @@ class HashBase : public SketchBase<std::vector<T>, true> {
              size_t sketch_dim,
              size_t hash_size,
              HashAlgorithm hash_algorithm,
-             const std::string &name = "HashBash")
+             const std::string &name = "HashBase")
         : SketchBase<std::vector<T>, true>(name),
           set_size(set_size),
           sketch_dim(sketch_dim),

--- a/sketch/hash_base.hpp
+++ b/sketch/hash_base.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "sketch/sketch_base.hpp"
 #include "util/timer.hpp"
 #include "util/utils.hpp"
 
@@ -16,10 +17,15 @@ enum class HashAlgorithm { uniform, crc32 };
 HashAlgorithm parse_hash_algorithm(const std::string &name);
 
 template <typename T>
-class HashBase {
+class HashBase : public SketchBase<std::vector<T>, true> {
   public:
-    HashBase(T set_size, size_t sketch_dim, size_t hash_size, HashAlgorithm hash_algorithm)
-        : set_size(set_size),
+    HashBase(T set_size,
+             size_t sketch_dim,
+             size_t hash_size,
+             HashAlgorithm hash_algorithm,
+             const std::string &name = "HashBash")
+        : SketchBase<std::vector<T>, true>(name),
+          set_size(set_size),
           sketch_dim(sketch_dim),
           hash_size(2 * hash_size),
           hash_algorithm(hash_algorithm),

--- a/sketch/hash_base.hpp
+++ b/sketch/hash_base.hpp
@@ -39,7 +39,6 @@ class HashBase : public SketchBase<std::vector<T>, true> {
 
     void set_hashes_for_testing(const std::vector<std::unordered_map<T, T>> &h) { hashes = h; }
 
-
   protected:
     T set_size;
     size_t sketch_dim;

--- a/sketch/hash_min.hpp
+++ b/sketch/hash_min.hpp
@@ -29,8 +29,11 @@ class MinHash : public HashBase<T> {
      * @param set_size the number of elements in S,
      * @param sketch_dim the number of components (elements) in the sketch vector.
      */
-    MinHash(T set_size, size_t sketch_dim, HashAlgorithm hash_algorithm)
-        : HashBase<T>(set_size, sketch_dim, set_size, hash_algorithm) {}
+    MinHash(T set_size,
+            size_t sketch_dim,
+            HashAlgorithm hash_algorithm,
+            const std::string &name = "MH")
+        : HashBase<T>(set_size, sketch_dim, set_size, hash_algorithm, name) {}
 
     /**
      * Computes the min-hash sketch for the given kmers.

--- a/sketch/hash_ordered.hpp
+++ b/sketch/hash_ordered.hpp
@@ -6,6 +6,7 @@
 
 #include <iostream>
 #include <random>
+#include <string>
 
 namespace ts { // ts = Tensor Sketch
 
@@ -28,12 +29,13 @@ class OrderedMinHash : public HashBase<T> {
                    size_t sketch_dim,
                    size_t max_len,
                    size_t tup_len,
-                   HashAlgorithm hash_algorithm)
-        : HashBase<T>(set_size, sketch_dim, set_size * max_len, hash_algorithm),
+                   HashAlgorithm hash_algorithm,
+                   const std::string &name = "OMH")
+        : HashBase<T>(set_size, sketch_dim, set_size * max_len, hash_algorithm, name),
           max_len(max_len),
           tup_len(tup_len) {}
 
-    Vec2D<T> compute(const std::vector<T> &kmers) {
+    Vec2D<T> compute_2d(const std::vector<T> &kmers) {
         Vec2D<T> sketch(this->sketch_dim);
         if (kmers.size() < tup_len) {
             throw std::invalid_argument("Sequence of kmers must be longer than tuple length");
@@ -67,11 +69,11 @@ class OrderedMinHash : public HashBase<T> {
         return sketch;
     }
 
-    std::vector<T> compute_flat(const std::vector<T> &kmers) {
+    std::vector<T> compute(const std::vector<T> &kmers) {
         Timer timer("ordered_minhash");
         std::vector<T> sketch;
 
-        Vec2D<T> sketch2D = compute(kmers);
+        Vec2D<T> sketch2D = compute_2d(kmers);
         for (const auto &tuple : sketch2D) {
             T sum = 0;
             for (const auto &item : tuple) {

--- a/sketch/hash_ordered.hpp
+++ b/sketch/hash_ordered.hpp
@@ -95,7 +95,7 @@ class OrderedMinHash : public HashBase<T> {
      * @tparam C the type of characters in the sequence
      */
     template <typename C>
-    Vec2D<T> compute(const std::vector<C> &sequence, uint32_t k, uint32_t alphabet_size) {
+    std::vector<T> compute(const std::vector<C> &sequence, uint32_t k, uint32_t alphabet_size) {
         return compute(seq2kmer<C, T>(sequence, k, alphabet_size));
     }
 

--- a/sketch/hash_weighted.hpp
+++ b/sketch/hash_weighted.hpp
@@ -33,8 +33,13 @@ class WeightedMinHash : public HashBase<T> {
      * @param sketch_dim the number of components (elements) in the sketch vector.
      * @param max_len maximum sequence length to be hashed.
      */
-    WeightedMinHash(T set_size, size_t sketch_dim, size_t max_len, HashAlgorithm hash_algorithm)
-        : HashBase<T>(set_size, sketch_dim, max_len * set_size, hash_algorithm), max_len(max_len) {}
+    WeightedMinHash(T set_size,
+                    size_t sketch_dim,
+                    size_t max_len,
+                    HashAlgorithm hash_algorithm,
+                    const std::string &name = "WMH")
+        : HashBase<T>(set_size, sketch_dim, max_len * set_size, hash_algorithm, name),
+          max_len(max_len) {}
 
     std::vector<T> compute(const std::vector<T> &kmers) {
         Timer timer("weighted_minhash");

--- a/sketch/sketch_base.hpp
+++ b/sketch/sketch_base.hpp
@@ -5,14 +5,20 @@
 #include <utility>
 namespace ts {
 
-template <typename sketch_type_, bool kmer_input_>
+/**
+ * A base class for sketch algorithms.
+ *
+ * @tparam SketchType the type returned by the compute() function.
+ * @tparam KmerInput is true when the hash algorithm first should convert the sequence to kmers.
+ * */
+template <typename SketchType, bool KmerInput>
 class SketchBase {
   public:
     // The type that the compute function returns.
-    using sketch_type = sketch_type_;
+    using sketch_type = SketchType;
 
     // Whether the compute function takes a list of kmers.
-    constexpr static bool kmer_input = kmer_input_;
+    constexpr static bool kmer_input = KmerInput;
 
     // Whether transformations should be applied to the sketch output of this algorithm.
     constexpr static bool transform_sketches = false;

--- a/sketch/sketch_base.hpp
+++ b/sketch/sketch_base.hpp
@@ -14,6 +14,9 @@ class SketchBase {
     // Whether the compute function takes a list of kmers.
     constexpr static bool kmer_input = kmer_input_;
 
+    // Whether transformations should be applied to the sketch output of this algorithm.
+    constexpr static bool transform_sketches = false;
+
     // The name of the sketching algorithm.
     const std::string name;
 

--- a/sketch/sketch_base.hpp
+++ b/sketch/sketch_base.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <exception>
 #include <string>
 #include <utility>

--- a/sketch/sketch_base.hpp
+++ b/sketch/sketch_base.hpp
@@ -1,0 +1,16 @@
+#include <exception>
+#include <string>
+#include <utility>
+namespace ts {
+
+template <typename sketch_type_, bool kmer_input_>
+class SketchBase {
+  public:
+    using sketch_type = sketch_type_;
+    constexpr static bool kmer_input = kmer_input_;
+    const std::string name;
+
+    explicit SketchBase(std::string name) : name(std::move(name)) {}
+};
+
+} // namespace ts

--- a/sketch/sketch_base.hpp
+++ b/sketch/sketch_base.hpp
@@ -8,8 +8,13 @@ namespace ts {
 template <typename sketch_type_, bool kmer_input_>
 class SketchBase {
   public:
+    // The type that the compute function returns.
     using sketch_type = sketch_type_;
+
+    // Whether the compute function takes a list of kmers.
     constexpr static bool kmer_input = kmer_input_;
+
+    // The name of the sketching algorithm.
     const std::string name;
 
     explicit SketchBase(std::string name) : name(std::move(name)) {}

--- a/sketch/tensor.hpp
+++ b/sketch/tensor.hpp
@@ -2,6 +2,7 @@
 
 #include "immintrin.h" // for AVX
 #include "nmmintrin.h" // for SSE4.2
+#include "sketch//sketch_base.hpp"
 #include "util/multivec.hpp"
 #include "util/timer.hpp"
 #include "util/utils.hpp"
@@ -18,11 +19,8 @@ namespace ts { // ts = Tensor Sketch
  * @tparam seq_type the type of elements in the sequences to be sketched.
  */
 template <class seq_type>
-class Tensor {
+class Tensor : public SketchBase<std::vector<double>, false> {
   public:
-    using sketch_type = std::vector<double>;
-
-    Tensor() {}
     /**
      * @param alphabet_size the number of elements in the alphabet S over which sequences are
      * defined (e.g. 4 for DNA)
@@ -30,8 +28,12 @@ class Tensor {
      * @param subsequence_len the length of the subsequences considered for sketching, denoted by t
      * in the paper
      */
-    Tensor(seq_type alphabet_size, size_t sketch_dim, size_t subsequence_len)
-        : alphabet_size(alphabet_size),
+    Tensor(seq_type alphabet_size,
+           size_t sketch_dim,
+           size_t subsequence_len,
+           const std::string &name = "TS")
+        : SketchBase<std::vector<double>, false>(name),
+          alphabet_size(alphabet_size),
           sketch_dim(sketch_dim),
           subsequence_len(subsequence_len),
           hashes(new2D<seq_type>(subsequence_len, alphabet_size)),

--- a/sketch/tensor.hpp
+++ b/sketch/tensor.hpp
@@ -1,15 +1,14 @@
 #pragma once
 
+#include "immintrin.h" // for AVX
+#include "nmmintrin.h" // for SSE4.2
 #include "util/multivec.hpp"
-
-#include <cassert>
-#include <iostream> //todo: remove
-#include <random>
-#include <cmath>
 #include "util/timer.hpp"
 #include "util/utils.hpp"
-#include "nmmintrin.h" // for SSE4.2
-#include "immintrin.h" // for AVX
+
+#include <cassert>
+#include <cmath>
+#include <random>
 
 namespace ts { // ts = Tensor Sketch
 
@@ -21,6 +20,8 @@ namespace ts { // ts = Tensor Sketch
 template <class seq_type>
 class Tensor {
   public:
+    using sketch_type = std::vector<double>;
+
     Tensor() {}
     /**
      * @param alphabet_size the number of elements in the alphabet S over which sequences are
@@ -102,9 +103,9 @@ class Tensor {
   protected:
     /** Computes (1-z)*a + z*b_shift */
     inline std::vector<double> shift_sum(const std::vector<double> &a,
-                                  const std::vector<double> &b,
-                                  seq_type shift,
-                                  double z) {
+                                         const std::vector<double> &b,
+                                         seq_type shift,
+                                         double z) {
         assert(a.size() == b.size());
         size_t len = a.size();
         std::vector<double> result(a.size());
@@ -117,9 +118,9 @@ class Tensor {
 
     /** Computes (1-z)*a + z*b_shift */
     void shift_sum_inplace(std::vector<double> &a,
-                                         const std::vector<double> &b,
-                                         seq_type shift,
-                                         double z) {
+                           const std::vector<double> &b,
+                           seq_type shift,
+                           double z) {
         assert(a.size() == b.size());
         size_t len = a.size();
         for (uint32_t i = 0; i < len; i++) {

--- a/sketch/tensor.hpp
+++ b/sketch/tensor.hpp
@@ -21,6 +21,9 @@ namespace ts { // ts = Tensor Sketch
 template <class seq_type>
 class Tensor : public SketchBase<std::vector<double>, false> {
   public:
+    // Tensor sketch output should be transformed if the command line flag is set.
+    constexpr static bool transform_sketches = false;
+
     /**
      * @param alphabet_size the number of elements in the alphabet S over which sequences are
      * defined (e.g. 4 for DNA)

--- a/sketch/tensor_slide.hpp
+++ b/sketch/tensor_slide.hpp
@@ -23,10 +23,11 @@ class TensorSlide : public Tensor<seq_type> {
      * @param alphabet_size the number of elements in the alphabet S over which sequences are
      * defined (e.g. 4 for DNA)
      * @param sketch_dim the dimension of the embedded (sketched) space, denoted by D in the paper
-     * @param subsequence_len the length of the subsequences considered for sketching, denoted by t
+     * @param tup_len the length of the subsequences considered for sketching, denoted by t
      * in the paper
      * @param win_len sliding sketches are computed for substrings of size win_len
      * @param stride sliding sketches are computed every stride characters
+     * @param name the name of the algorithm in the output
      */
     TensorSlide(seq_type alphabet_size,
                 size_t sketch_dim,

--- a/sketch/tensor_slide.hpp
+++ b/sketch/tensor_slide.hpp
@@ -4,9 +4,9 @@
 
 #include "util/utils.hpp"
 
+#include <bit>
 #include <cstddef>
 #include <vector>
-#include <bit>
 
 namespace ts {
 /**
@@ -17,7 +17,7 @@ namespace ts {
 template <class seq_type>
 class TensorSlide : public Tensor<seq_type> {
   public:
-    TensorSlide() {}
+    using sketch_type = Vec2D<double>;
 
     /**
      * @param alphabet_size the number of elements in the alphabet S over which sequences are
@@ -32,9 +32,11 @@ class TensorSlide : public Tensor<seq_type> {
                 size_t sketch_dim,
                 size_t tup_len,
                 size_t win_len,
-                size_t stride)
-        : Tensor<seq_type>(alphabet_size, sketch_dim, tup_len),
-                win_len(win_len), stride(stride) {
+                size_t stride,
+                const std::string &name = "TSS")
+        : Tensor<seq_type>(alphabet_size, sketch_dim, tup_len, name),
+          win_len(win_len),
+          stride(stride) {
         assert(stride <= win_len && "Stride cannot be larger than the window length");
         assert(tup_len <= stride && "Tuple length (t) cannot be larger than the stride");
     }

--- a/sketch/tensor_slide_flat.hpp
+++ b/sketch/tensor_slide_flat.hpp
@@ -2,10 +2,17 @@
 
 namespace ts {
 
-// Flattener: one of the classes from util/dim_reduce.h.
+/**
+ * A wrapper class around TensorSlide that flattens the output of TensorSlide::compute() from a 2D
+ * vector to a 1D vector. The Flattener type must have a .flatten method that does the conversion.
+ * Typically used with a class form sketch/dim_reduce.h.
+ *
+ * @tparam seq_type the type of elements in the sequences to be sketched.
+ * @tparam Flattener: one of the classes from util/dim_reduce.h.
+ */
 template <class seq_type, class Flattener>
 class TensorSlideFlat : public TensorSlide<seq_type> {
-    Flattener flattener_;
+    Flattener flattener;
 
   public:
     using sketch_type = typename Flattener::sketch_type;
@@ -14,10 +21,11 @@ class TensorSlideFlat : public TensorSlide<seq_type> {
      * @param alphabet_size the number of elements in the alphabet S over which sequences are
      * defined (e.g. 4 for DNA)
      * @param sketch_dim the dimension of the embedded (sketched) space, denoted by D in the paper
-     * @param subsequence_len the length of the subsequences considered for sketching, denoted by t
+     * @param tup_len the length of the subsequences considered for sketching, denoted by t
      * in the paper
      * @param win_len sliding sketches are computed for substrings of size win_len
      * @param stride sliding sketches are computed every stride characters
+     * @param flattener the object to use to flatten the compute output.
      */
     TensorSlideFlat(seq_type alphabet_size,
                     size_t sketch_dim,
@@ -27,7 +35,7 @@ class TensorSlideFlat : public TensorSlide<seq_type> {
                     Flattener flattener,
                     const std::string &name = "TSS")
         : TensorSlide<seq_type>(alphabet_size, sketch_dim, tup_len, win_len, stride, name),
-          flattener_(flattener) {}
+          flattener(flattener) {}
 
 
     /**
@@ -36,7 +44,7 @@ class TensorSlideFlat : public TensorSlide<seq_type> {
      * @return seq.size()/stride sketches of size #sketch_dim
      */
     sketch_type compute(const std::vector<seq_type> &seq) {
-        return flattener_.flatten(TensorSlide<seq_type>::compute(seq));
+        return flattener.flatten(TensorSlide<seq_type>::compute(seq));
     }
 
     static double dist(const sketch_type &a, const sketch_type &b) { return Flattener::dist(a, b); }

--- a/sketch/tensor_slide_flat.hpp
+++ b/sketch/tensor_slide_flat.hpp
@@ -1,0 +1,45 @@
+#include "sketch/tensor_slide.hpp"
+
+namespace ts {
+
+// Flattener: one of the classes from util/dim_reduce.h.
+template <class seq_type, class Flattener>
+class TensorSlideFlat : public TensorSlide<seq_type> {
+    Flattener flattener_;
+
+  public:
+    using sketch_type = typename Flattener::sketch_type;
+
+    /**
+     * @param alphabet_size the number of elements in the alphabet S over which sequences are
+     * defined (e.g. 4 for DNA)
+     * @param sketch_dim the dimension of the embedded (sketched) space, denoted by D in the paper
+     * @param subsequence_len the length of the subsequences considered for sketching, denoted by t
+     * in the paper
+     * @param win_len sliding sketches are computed for substrings of size win_len
+     * @param stride sliding sketches are computed every stride characters
+     */
+    TensorSlideFlat(seq_type alphabet_size,
+                    size_t sketch_dim,
+                    size_t tup_len,
+                    size_t win_len,
+                    size_t stride,
+                    Flattener flattener,
+                    const std::string &name = "TSS")
+        : TensorSlide<seq_type>(alphabet_size, sketch_dim, tup_len, win_len, stride, name),
+          flattener_(flattener) {}
+
+
+    /**
+     * Computes sliding sketches for the given sequence.
+     * A sketch is computed every #stride characters on substrings of length #window.
+     * @return seq.size()/stride sketches of size #sketch_dim
+     */
+    sketch_type compute(const std::vector<seq_type> &seq) {
+        return flattener_.flatten(TensorSlide<seq_type>::compute(seq));
+    }
+
+    static double dist(const sketch_type &a, const sketch_type &b) { return Flattener::dist(a, b); }
+};
+
+} // namespace ts

--- a/sketch_main.cpp
+++ b/sketch_main.cpp
@@ -199,7 +199,7 @@ int main(int argc, char *argv[]) {
                         = OrderedMinHash<uint64_t>(kmer_word_size, FLAGS_embed_dim, FLAGS_max_len,
                                                    FLAGS_tuple_length, HashAlgorithm::uniform)](
                                const std::vector<uint64_t> &seq) mutable {
-                return omin_hash.compute_flat(seq);
+                return omin_hash.compute(seq);
             };
         }
         std::function<Vec2D<double>(const std::vector<uint64_t> &)> slide_sketcher

--- a/tests/sketch/test_ordered_min_hash.cpp
+++ b/tests/sketch/test_ordered_min_hash.cpp
@@ -1,7 +1,7 @@
 #include "sketch/hash_ordered.hpp"
 
-#include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
 #include <random>
 
@@ -26,8 +26,8 @@ TEST(OrderedMinHash, Repeat) {
     OrderedMinHash<uint8_t> under_test(set_size, sketch_dim, max_sequence_len, tuple_length,
                                        HashAlgorithm::uniform);
     std::vector<uint8_t> sequence = { 0, 1, 2, 3, 4, 5 };
-    Vec2D<uint8_t> sketch1 = under_test.compute(sequence);
-    Vec2D<uint8_t> sketch2 = under_test.compute(sequence);
+    Vec2D<uint8_t> sketch1 = under_test.compute_2d(sequence);
+    Vec2D<uint8_t> sketch2 = under_test.compute_2d(sequence);
     ASSERT_EQ(sketch_dim, sketch1.size());
     ASSERT_EQ(sketch_dim, sketch2.size());
     for (uint32_t i = 0; i < sketch_dim; ++i) {
@@ -40,8 +40,8 @@ TEST(OrderedMinHash, ReverseOrder) {
                                        HashAlgorithm::uniform);
     std::vector<uint8_t> sequence1 = { 0, 1, 2, 3, 4, 5 };
     std::vector<uint8_t> sequence2 = { 5, 4, 3, 2, 1, 0 };
-    Vec2D<uint8_t> sketch1 = under_test.compute(sequence1);
-    Vec2D<uint8_t> sketch2 = under_test.compute(sequence2);
+    Vec2D<uint8_t> sketch1 = under_test.compute_2d(sequence1);
+    Vec2D<uint8_t> sketch2 = under_test.compute_2d(sequence2);
     ASSERT_EQ(sketch_dim, sketch1.size());
     ASSERT_EQ(sketch_dim, sketch2.size());
     for (uint32_t i = 0; i < sketch_dim; ++i) {
@@ -68,7 +68,7 @@ TEST(OrderedMinHash, PresetHash) {
     for (uint32_t i = 0; i < set_size - tuple_length; ++i) {
         std::vector<uint8_t> sequence(set_size - i);
         std::iota(sequence.begin(), sequence.end(), i);
-        Vec2D<uint8_t> sketch = under_test.compute(sequence);
+        Vec2D<uint8_t> sketch = under_test.compute_2d(sequence);
         for (uint32_t s = 0; s < sketch_dim; ++s) {
             ASSERT_THAT(sketch[s], ElementsAreArray({ i, i + 1, i + 2 }));
         }
@@ -83,7 +83,7 @@ TEST(OrderedMinHash, PresetHashRepeat) {
         std::vector<uint8_t> sequence(2 * (set_size - i));
         std::iota(sequence.begin(), sequence.begin() + sequence.size() / 2, i);
         std::iota(sequence.begin() + sequence.size() / 2, sequence.end(), i);
-        Vec2D<uint8_t> sketch = under_test.compute(sequence);
+        Vec2D<uint8_t> sketch = under_test.compute_2d(sequence);
         for (uint32_t s = 0; s < sketch_dim; ++s) {
             ASSERT_THAT(sketch[s], ElementsAreArray({ i, i + 1, i + 2 }));
         }

--- a/util/multivec.hpp
+++ b/util/multivec.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
+#include "util/transformer.hpp"
+
+#include <functional>
 #include <type_traits>
 #include <vector>
-#include <functional>
-#include "util/transformer.hpp"
 
 namespace ts { // ts = Tensor Sketch
 
@@ -30,23 +31,23 @@ auto new3D(size_t d1, size_t d2, size_t d3, T val = 0) {
 }
 
 template <class T>
-void apply1D(std::vector<T> &vec, const transformer<T> &tr) {
+void apply(std::vector<T> &vec, const transformer<T> &tr) {
     for (auto &v : vec) {
         v = tr.transform(v);
     }
 }
 
 template <class T>
-void apply2D(Vec2D<T> &vec2D, const transformer<T> &tr) {
-    for (auto & vec : vec2D) {
-        apply1D(vec, tr);
+void apply(Vec2D<T> &vec2D, const transformer<T> &tr) {
+    for (auto &vec : vec2D) {
+        apply(vec, tr);
     }
 }
 
 template <class T>
-void apply3D(Vec3D<double> &vec3D, const transformer<T> &tr) {
+void apply(Vec3D<double> &vec3D, const transformer<T> &tr) {
     for (auto &vec2D : vec3D) {
-       apply2D(vec2D, tr);
+        apply(vec2D, tr);
     }
 }
 

--- a/util/spearman.hpp
+++ b/util/spearman.hpp
@@ -55,8 +55,8 @@ double pearson(const std::vector<T> &a, const std::vector<T> &b) {
     return (a.size() * sum_ab - sum_a * sum_b) / std::sqrt(var_a * var_b);
 }
 
-template <typename T>
-double spearman(const std::vector<T> &a, const std::vector<T> &b) {
+template <typename T, typename U>
+double spearman(const std::vector<T> &a, const std::vector<U> &b) {
     std::vector<double> rank1 = rankify(a);
     std::vector<double> rank2 = rankify(b);
     return pearson(rank1, rank2);

--- a/util/transformer.hpp
+++ b/util/transformer.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
-#include <vector>
+#include <algorithm>
 #include <cmath>
+#include <vector>
 
-namespace ts{
+namespace ts {
 
 template <class T>
 class transformer {
@@ -11,13 +12,13 @@ class transformer {
     virtual T transform(T val) const = 0;
 };
 
-template<class T>
+template <class T>
 class discretize : public transformer<T> {
   public:
     explicit discretize(size_t num_bins) : num_bins(num_bins) {
         bins = std::vector<double>(num_bins);
         for (size_t b = 0; b < num_bins; b++) {
-            bins[b] = std::tan(M_PI * (((double) b + .5) / num_bins - .5 ));
+            bins[b] = std::tan(M_PI * (((double)b + .5) / num_bins - .5));
         }
         bins.push_back(std::numeric_limits<double>::max());
         bins.insert(bins.begin(), -std::numeric_limits<double>::max());
@@ -34,15 +35,12 @@ class discretize : public transformer<T> {
   private:
     /** number of bins used to discretize the output*/
     size_t num_bins;
-
 };
 
-template<class T>
+template <class T>
 class atan_scaler : public transformer<T> {
   public:
-    T transform (T val ) const override {
-        return atan(val);
-    }
+    T transform(T val) const override { return atan(val); }
 };
 
-}
+} // namespace ts

--- a/util/utils.hpp
+++ b/util/utils.hpp
@@ -178,4 +178,33 @@ T int_pow(T x, T pow) {
 
 std::string flag_values(char delimiter = ' ', bool skip_empty = false);
 
+template <typename F, typename T>
+void apply_tuple(F &&f, T &tuple_t) {
+    std::apply([&](auto &...t) { (f(t), ...); }, tuple_t);
+}
+
+
+template <typename F, typename... Ts, typename... Us>
+void apply_tuple(F &&f, std::tuple<Ts...> &tuple_t, std::tuple<Us...> &tuple_u) {
+    std::apply([&](auto &...ts) { std::apply([&](auto &...us) { (f(ts, us), ...); }, tuple_u); },
+               tuple_t);
+}
+
+template <typename F, typename... Ts, typename... Us, typename... Vs>
+void apply_tuple(F &&f,
+                 std::tuple<Ts...> &tuple_t,
+                 std::tuple<Us...> &tuple_u,
+                 std::tuple<Vs...> &tuple_v) {
+    std::apply(
+            [&](auto &...ts) {
+                std::apply(
+                        [&](auto &...us) {
+                            std::apply([&](auto &...vs) { (f(ts, us, vs), ...); }, tuple_v);
+                        },
+                        tuple_u);
+            },
+            tuple_t);
+}
+
+
 } // namespace ts

--- a/util/utils.hpp
+++ b/util/utils.hpp
@@ -178,32 +178,10 @@ T int_pow(T x, T pow) {
 
 std::string flag_values(char delimiter = ' ', bool skip_empty = false);
 
+// A simple wrapper around std::apply that applies a given lambda on each element of a tuple.
 template <typename F, typename T>
 void apply_tuple(F &&f, T &tuple_t) {
     std::apply([&](auto &...t) { (f(t), ...); }, tuple_t);
-}
-
-
-template <typename F, typename... Ts, typename... Us>
-void apply_tuple(F &&f, std::tuple<Ts...> &tuple_t, std::tuple<Us...> &tuple_u) {
-    std::apply([&](auto &...ts) { std::apply([&](auto &...us) { (f(ts, us), ...); }, tuple_u); },
-               tuple_t);
-}
-
-template <typename F, typename... Ts, typename... Us, typename... Vs>
-void apply_tuple(F &&f,
-                 std::tuple<Ts...> &tuple_t,
-                 std::tuple<Us...> &tuple_u,
-                 std::tuple<Vs...> &tuple_v) {
-    std::apply(
-            [&](auto &...ts) {
-                std::apply(
-                        [&](auto &...us) {
-                            std::apply([&](auto &...vs) { (f(ts, us, vs), ...); }, tuple_v);
-                        },
-                        tuple_u);
-            },
-            tuple_t);
 }
 
 


### PR DESCRIPTION
@danieldanciu Do you like where this is going?
I got carried away a bit, having fun playing with parameter packs. It's all compiling now on my end, but it's probably not the most readable code anymore. (didn't do cleanup and such; just proof of concept for now)

The benefit of the current approach (basically following the original) is that all actions happen in parallel for all algorithms (first compute all sketches, then all distances, then all spearman coefficients).

OTOH, it would probably be cleaner to first compute the set of sequences and edit distances, and then run the different sketch algorithms in sequence, doing all steps for each algorithm at once.
That would basically change the `ExperimentRunner` class to only have a single sketch algorithm as parameter, instead of all of them at the same time.

