### PR TITLE
Implementation of TensorBlock, a generalization of TensorSketch for spaced k-mers

### DIFF
--- a/experiments_flags
+++ b/experiments_flags
@@ -1,16 +1,17 @@
 # sequence generation
 --alphabet_size=4
---seq_len=10000
---num_seqs=1000
+--seq_len=1000
+--num_seqs=100
 --group_size=2
 --phylogeny_shape=path
 --fix_len=true
---max_mutation_rate=1.0
+--max_mutation_rate=0.1
 --min_mutation_rate=0.0
 # sketching methods
 --embed_dim=16
---kmer_size=4
---tuple_length=3
+--kmer_size=9
+--tuple_length=12
+--block_size=6
 --window_size=2000
 --stride=1000
 --tss_dim=4

--- a/experiments_flags
+++ b/experiments_flags
@@ -1,17 +1,17 @@
 # sequence generation
 --alphabet_size=4
---seq_len=1000
---num_seqs=100
+--seq_len=10000
+--num_seqs=1000
 --group_size=2
 --phylogeny_shape=path
 --fix_len=true
---max_mutation_rate=0.1
+--max_mutation_rate=1.0
 --min_mutation_rate=0.0
 # sketching methods
 --embed_dim=16
---kmer_size=9
---tuple_length=12
---block_size=6
+--kmer_size=4
+--tuple_length=3
+--block_size=2
 --window_size=2000
 --stride=1000
 --tss_dim=4

--- a/experiments_main.cpp
+++ b/experiments_main.cpp
@@ -448,8 +448,8 @@ int main(int argc, char *argv[]) {
                                       parse_hash_algorithm(FLAGS_hash_alg), rd(), "OMH",
                                       FLAGS_omh_kmer_size),
             Tensor<char_type>(FLAGS_alphabet_size, FLAGS_ts_dim, FLAGS_ts_tuple_length, rd(), "TS"),
-            TensorBlock<char_type>(FLAGS_block_size, FLAGS_alphabet_size, FLAGS_ts_dim,
-                                   FLAGS_ts_tuple_length, rd(), "TSB"),
+            TensorBlock<char_type>(FLAGS_alphabet_size, FLAGS_ts_dim, FLAGS_ts_tuple_length,
+                                   FLAGS_block_size, rd(), "TSB"),
             TensorSlide<char_type>(FLAGS_alphabet_size, FLAGS_tss_dim, FLAGS_tss_tuple_length,
                                    FLAGS_tss_window_size, FLAGS_tss_stride, rd(), "TSS"),
             TensorSlideFlat<char_type, Int32Flattener>(

--- a/experiments_main.cpp
+++ b/experiments_main.cpp
@@ -51,6 +51,19 @@ DEFINE_int32(tuple_length,
              3,
              "Ordered tuple length, used in ordered MinHash and Tensor-based sketches");
 
+
+static bool ValidateBlockSize(const char *flagname, int32_t value) {
+    if (FLAGS_tuple_length % value == 0) {
+        return true;
+    }
+    printf("Invalid value for --%s: %d. Must be a divisor of --tuple_len\n", flagname, value);
+    return false;
+}
+DEFINE_int32(block_size,
+             1,
+             "Only consider tuples made out of block-size continuous characters for Tensor sketch");
+DEFINE_validator(block_size, &ValidateBlockSize);
+
 DEFINE_int32(
         max_len,
         0,
@@ -435,6 +448,8 @@ int main(int argc, char *argv[]) {
                                       parse_hash_algorithm(FLAGS_hash_alg), rd(), "OMH",
                                       FLAGS_omh_kmer_size),
             Tensor<char_type>(FLAGS_alphabet_size, FLAGS_ts_dim, FLAGS_ts_tuple_length, rd(), "TS"),
+            TensorBlock<char_type>(FLAGS_block_size, FLAGS_alphabet_size, FLAGS_ts_dim,
+                                   FLAGS_ts_tuple_length, rd(), "TSB"),
             TensorSlide<char_type>(FLAGS_alphabet_size, FLAGS_tss_dim, FLAGS_tss_tuple_length,
                                    FLAGS_tss_window_size, FLAGS_tss_stride, rd(), "TSS"),
             TensorSlideFlat<char_type, Int32Flattener>(

--- a/experiments_main.cpp
+++ b/experiments_main.cpp
@@ -6,6 +6,7 @@
 #include "sketch/hash_ordered.hpp"
 #include "sketch/hash_weighted.hpp"
 #include "sketch/tensor.hpp"
+#include "sketch/tensor_block.hpp"
 #include "sketch/tensor_slide.hpp"
 #include "sketch/tensor_slide_flat.hpp"
 #include "util/multivec.hpp"

--- a/sketch/tensor.hpp
+++ b/sketch/tensor.hpp
@@ -9,7 +9,6 @@
 
 #include <cassert>
 #include <cmath>
-#include <iostream>
 #include <random>
 
 namespace ts { // ts = Tensor Sketch
@@ -118,21 +117,6 @@ class Tensor : public SketchBase<std::vector<double>, false> {
     }
 
   protected:
-    /** Computes (1-z)*a + z*b_shift */
-    inline std::vector<double> shift_sum(const std::vector<double> &a,
-                                         const std::vector<double> &b,
-                                         seq_type shift,
-                                         double z) {
-        assert(a.size() == b.size());
-        const size_t len = a.size();
-        std::vector<double> result(a.size());
-        for (uint32_t i = 0; i < a.size(); i++) {
-            result[i] = (1 - z) * a[i] + z * b[(len + i - shift) % len];
-            assert(result[i] <= 1 + 1e-5 && result[i] >= -1e-5);
-        }
-        return result;
-    }
-
     /** Computes (1-z)*a + z*b_shift */
     void shift_sum_inplace(std::vector<double> &a,
                            const std::vector<double> &b,

--- a/sketch/tensor_block.hpp
+++ b/sketch/tensor_block.hpp
@@ -38,10 +38,10 @@ class TensorBlock : public SketchBase<std::vector<double>, false> {
      * @param seed the seed to initialize the random number generator used for the random hash
      * functions.
      */
-    TensorBlock(uint8_t block_size,
-                seq_type alphabet_size,
+    TensorBlock(seq_type alphabet_size,
                 size_t sketch_dim,
                 size_t subsequence_len,
+                uint8_t block_size,
                 uint32_t seed,
                 const std::string &name = "TSB")
         : SketchBase<std::vector<double>, false>(name),

--- a/sketch/tensor_block.hpp
+++ b/sketch/tensor_block.hpp
@@ -125,7 +125,7 @@ class TensorBlock : public SketchBase<std::vector<double>, false> {
             Tm.push_back(std::move(nTm));
             nTp = std::move(Tp.front());
             nTm = std::move(Tm.front());
-            for (uint32_t j = 0; j < subsequence_len + 1; ++j) {
+            for (uint8_t j = 0; j < subsequence_len + 1; ++j) {
                 std::fill(nTp[j].begin(), nTp[j].end(), 0);
                 std::fill(nTm[j].begin(), nTm[j].end(), 0);
             }

--- a/sketch/tensor_block.hpp
+++ b/sketch/tensor_block.hpp
@@ -1,0 +1,193 @@
+#pragma once
+
+#include "immintrin.h" // for AVX
+#include "nmmintrin.h" // for SSE4.2
+#include "sketch//sketch_base.hpp"
+#include "util/multivec.hpp"
+#include "util/timer.hpp"
+#include "util/utils.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <deque>
+#include <random>
+
+namespace ts { // ts = Tensor Sketch
+
+/**
+ * Computes tensor sketches for a given sequence as described in
+ * https://www.biorxiv.org/content/10.1101/2020.11.13.381814v1, with the additional limitation that
+ * the subsequences must be made of continuous blocks of a certain size. The adaptation of the
+ * recurrence formula for this case is at https://go.grlab.org/tensor_block.
+ * For block_size=1, the normal the #TensorBlock sketch is identical with #Tensor sketch.
+ * @tparam seq_type the type of elements in the sequences to be sketched.
+ */
+template <class seq_type>
+class TensorBlock : public SketchBase<std::vector<double>, false> {
+  public:
+    // Tensor sketch output should be transformed if the command line flag is set.
+    constexpr static bool transform_sketches = false;
+
+    /**
+     * @param block_size only subsequences formed out of block_size continuous elements are sketched
+     * @param alphabet_size the number of elements in the alphabet S over which sequences are
+     * defined (e.g. 4 for DNA, 20 for protein, etc.)
+     * @param sketch_dim the dimension of the embedded (sketched) space, denoted by D in the paper
+     * @param subsequence_len the length of the subsequences considered for sketching, denoted by t
+     * in the paper
+     * @param seed the seed to initialize the random number generator used for the random hash
+     * functions.
+     */
+    TensorBlock(uint8_t block_size,
+                seq_type alphabet_size,
+                size_t sketch_dim,
+                size_t subsequence_len,
+                uint32_t seed,
+                const std::string &name = "TS")
+        : SketchBase<std::vector<double>, false>(name),
+          block_size(block_size),
+          alphabet_size(alphabet_size),
+          sketch_dim(sketch_dim),
+          subsequence_len(subsequence_len),
+          rng(seed) {
+        assert(block_size > 0 && subsequence_len > 0 && subsequence_len % block_size == 0);
+        init();
+    }
+
+    void init() {
+        hashes = new2D<seq_type>(subsequence_len, alphabet_size);
+        signs = new2D<bool>(subsequence_len, alphabet_size);
+
+        std::uniform_int_distribution<seq_type> rand_hash2(0, sketch_dim - 1);
+        std::uniform_int_distribution<seq_type> rand_bool(0, 1);
+
+        for (size_t h = 0; h < subsequence_len; h++) {
+            for (size_t c = 0; c < alphabet_size; c++) {
+                hashes[h][c] = rand_hash2(rng);
+                signs[h][c] = rand_bool(rng);
+            }
+        }
+    }
+
+    /**
+     * Computes the sketch of the given sequence.
+     * @param seq the sequence to be sketched
+     * @return an array of size #sketch_dim containing the sequence's sketch
+     */
+    std::vector<double> compute(const std::vector<seq_type> &seq) {
+        Timer timer("tensor_sketch");
+        // Tp corresponds to T+, Tm to T- in the paper; Tp[0], Tm[0] are sentinels and contain the
+        // initial condition for empty strings; Tp[p], Tm[p] at step i represent the partial sketch
+        // when considering hashes h1...hp, over the prefix x1...xi. The final result is then
+        // Tp[t]-Tm[t], where t is #sequence_len
+        // since the recurrence formula references the T_[1:N-k], i.e. the element situated
+        // k=block_size positions behind, we need to always keep the last block_size Tp and Tm
+        // matrices. At each iteration we create a new pair of Tp and Tm and then discard the oldest
+        // Tp/Tn pair.
+        std::deque<Vec2D<double>> Tp;
+        std::deque<Vec2D<double>> Tm;
+        for (uint32_t i = 0; i < block_size; ++i) {
+            Tp.push_back(new2D<double>(subsequence_len + 1, sketch_dim, 0));
+            Tm.push_back(new2D<double>(subsequence_len + 1, sketch_dim, 0));
+            // the initial condition states that the sketch for the empty string is (1,0,..)
+            Tp.back()[0][0] = 1;
+        }
+
+        uint32_t m = subsequence_len / block_size;
+        // the are the "new" Tp and Tm, computed at every iteration and appended to Tp and Tm
+        auto nTp = new2D<double>(subsequence_len + 1, sketch_dim, 0);
+        auto nTm = new2D<double>(subsequence_len + 1, sketch_dim, 0);
+        for (uint32_t i = block_size - 1; i < seq.size(); i++) {
+            uint32_t block_count = std::min(m, (i + 1) / block_size);
+            // must traverse in reverse order, to avoid overwriting the values of Tp and Tm before
+            // they are used in the recurrence
+            // p must be a multiple of block_size
+            for (uint32_t bc = block_count; bc > 0; bc--) {
+                uint32_t p = bc * block_size;
+                double z = bc / (i + 1.0 - p + bc); // probability that the last index is i
+                seq_type r = 0;
+                bool s = true;
+                for (uint32_t j = 0; j < block_size; ++j) {
+                    r += hashes[p - j - 1][seq[i - j]];
+                    s = s == signs[p - j - 1][seq[i - j]];
+                }
+                r %= sketch_dim;
+                if (s) {
+                    nTp[p] = this->shift_sum(Tp.back()[p], Tp[0][p - block_size], r, z);
+                    nTm[p] = this->shift_sum(Tm.back()[p], Tm[0][p - block_size], r, z);
+                } else {
+                    nTp[p] = this->shift_sum(Tp.back()[p], Tm[0][p - block_size], r, z);
+                    nTm[p] = this->shift_sum(Tm.back()[p], Tp[0][p - block_size], r, z);
+                }
+            }
+            nTp[0][0] = 1;
+            Tp.push_back(std::move(nTp));
+            Tm.push_back(std::move(nTm));
+            nTp = std::move(Tp.front());
+            nTm = std::move(Tm.front());
+            for (uint32_t j = 0; j < subsequence_len + 1; ++j) {
+                std::fill(nTp[j].begin(), nTp[j].end(), 0);
+                std::fill(nTm[j].begin(), nTm[j].end(), 0);
+            }
+            Tp.pop_front();
+            Tm.pop_front();
+        }
+        std::vector<double> sketch(sketch_dim, 0);
+        for (uint32_t l = 0; l < sketch_dim; l++) {
+            sketch[l] = Tp.back()[subsequence_len][l] - Tm.back()[subsequence_len][l];
+        }
+
+        return sketch;
+    }
+
+    /** Sets the hash and sign functions to predetermined values for testing */
+    void set_hashes_for_testing(const Vec2D<seq_type> &h, const Vec2D<bool> &s) {
+        hashes = h;
+        signs = s;
+    }
+
+    static double dist(const std::vector<double> &a, const std::vector<double> &b) {
+        Timer timer("tensor_sketch_dist");
+        return l2_dist(a, b);
+    }
+
+  protected:
+    /** Computes (1-z)*a + z*b_shift */
+    inline std::vector<double> shift_sum(const std::vector<double> &a,
+                                         const std::vector<double> &b,
+                                         seq_type shift,
+                                         double z) {
+        assert(a.size() == b.size());
+        size_t len = a.size();
+        std::vector<double> result(a.size());
+        for (uint32_t i = 0; i < a.size(); i++) {
+            result[i] = (1 - z) * a[i] + z * b[(len + i - shift) % len];
+            assert(result[i] <= 1 + 1e-5 && result[i] >= -1e-5);
+        }
+        return result;
+    }
+
+    /** The size of the block each subsequence is made of. Must be a divisor of #subsequence_len.
+     * A block size of 1 means that the class is operating on a character basis. */
+    uint8_t block_size;
+
+    /** Size of the alphabet over which sequences to be sketched are defined, e.g. 4 for DNA */
+    seq_type alphabet_size;
+    /** Number of elements in the sketch, denoted by D in the paper */
+    uint32_t sketch_dim;
+    /** The length of the subsequences considered for sketching, denoted by t in the paper */
+    uint8_t subsequence_len;
+
+    /**
+     * Denotes the hash functions h1,....ht:A->{1....D}, where t is #subsequence_len and D is
+     * #sketch_dim
+     */
+    Vec2D<seq_type> hashes;
+
+    /** The sign functions s1...st:A->{-1,1} */
+    Vec2D<bool> signs;
+
+    std::mt19937 rng;
+};
+
+} // namespace ts

--- a/sketch/tensor_block.hpp
+++ b/sketch/tensor_block.hpp
@@ -43,7 +43,7 @@ class TensorBlock : public SketchBase<std::vector<double>, false> {
                 size_t sketch_dim,
                 size_t subsequence_len,
                 uint32_t seed,
-                const std::string &name = "TS")
+                const std::string &name = "TSB")
         : SketchBase<std::vector<double>, false>(name),
           block_size(block_size),
           alphabet_size(alphabet_size),

--- a/sketch/tensor_block.hpp
+++ b/sketch/tensor_block.hpp
@@ -84,6 +84,7 @@ class TensorBlock : public SketchBase<std::vector<double>, false> {
         // k=block_size positions behind, we need to always keep the last block_size Tp and Tm
         // matrices. At each iteration we create a new pair of Tp and Tm and then discard the oldest
         // Tp/Tn pair.
+        //TODO(ddanciu): use a circular queue on top of vector instead
         std::deque<Vec2D<double>> Tp;
         std::deque<Vec2D<double>> Tm;
         for (uint32_t i = 0; i < block_size; ++i) {

--- a/tests/sketch/test_tensor_block.cpp
+++ b/tests/sketch/test_tensor_block.cpp
@@ -31,7 +31,7 @@ void rand_init(uint32_t sketch_size, Vec2D<set_type> *hashes, Vec2D<bool> *signs
 }
 
 TEST(TensorBlock, Empty) {
-    TensorBlock<uint8_t> under_test(1, alphabet_size, sketch_dim, tuple_length, /*seed=*/31415);
+    TensorBlock<uint8_t> under_test(alphabet_size, sketch_dim, tuple_length, 1, /*seed=*/31415);
     std::vector<double> sketch = under_test.compute(std::vector<uint8_t>());
     ASSERT_EQ(sketch.size(), sketch_dim);
     ASSERT_THAT(sketch, ElementsAre(0, 0));
@@ -39,7 +39,7 @@ TEST(TensorBlock, Empty) {
 
 /** The sequence has one char, which is shorter than the tuple length, so the sketch will be 0 */
 TEST(TensorBlock, OneChar) {
-    TensorBlock<uint8_t> under_test(1, alphabet_size, sketch_dim, tuple_length, /*seed=*/31415);
+    TensorBlock<uint8_t> under_test(alphabet_size, sketch_dim, tuple_length, 1, /*seed=*/31415);
     for (uint8_t c = 0; c < alphabet_size; ++c) {
         std::vector<double> sketch = under_test.compute({ c });
         ASSERT_THAT(sketch, ElementsAre(0, 0));
@@ -50,7 +50,7 @@ TEST(TensorBlock, OneChar) {
  * position h(seq[0]) */
 TEST(TensorBlock, OneCharTuple1) {
     constexpr uint32_t tuple_len = 1;
-    TensorBlock<uint8_t> under_test(1, alphabet_size, sketch_dim, tuple_len, /*seed=*/31415);
+    TensorBlock<uint8_t> under_test(alphabet_size, sketch_dim, tuple_len, 1, /*seed=*/31415);
 
     Vec2D<uint8_t> hashes = new2D<uint8_t>(tuple_len, alphabet_size);
     Vec2D<bool> signs = new2D<bool>(tuple_len, alphabet_size);
@@ -79,7 +79,8 @@ TEST(TensorBlock, FullStringRandomChars) {
                     continue;
                 }
                 std::uniform_int_distribution<uint8_t> rand_char(0, alphabet_size - 1);
-                TensorBlock<uint8_t> under_test(block_size, alphabet_size, sketch_dimension, tuple_len,
+                TensorBlock<uint8_t> under_test(alphabet_size, sketch_dimension, tuple_len,
+                                                block_size,
                                                 /*seed=*/31415);
 
                 Vec2D<uint8_t> hashes = new2D<uint8_t>(tuple_len, alphabet_size);
@@ -125,7 +126,7 @@ TEST(TensorBlock, SameChars) {
                 if (tuple_len % block_size != 0) {
                     continue;
                 }
-                TensorBlock<uint8_t> under_test(block_size, tuple_len, sketch_dimension, tuple_len,
+                TensorBlock<uint8_t> under_test(tuple_len, sketch_dimension, tuple_len, block_size,
                                                 /*seed=*/127383);
                 uint8_t sequence_length = tuple_len + rand_seq_len(gen);
                 std::vector<uint8_t> sequence(sequence_length, rand_char(gen));
@@ -152,7 +153,7 @@ TEST(TensorBlock, DistinctCharsTuple1) {
     std::vector<uint8_t> sequence(alphabet_size);
     std::iota(sequence.begin(), sequence.end(), 0);
     for (uint32_t sketch_dimension = 3; sketch_dimension < 10; ++sketch_dimension) {
-        TensorBlock<uint8_t> under_test(1, alphabet_size, sketch_dimension, tuple_len,
+        TensorBlock<uint8_t> under_test(alphabet_size, sketch_dimension, tuple_len, 1,
                                         /*seed=*/31415);
 
         std::vector<double> sketch = under_test.compute(sequence);
@@ -180,8 +181,8 @@ TEST(TensorBlock, DistinctCharsTupleTMinus1) {
                 if (tuple_len % block_size != 0) {
                     continue;
                 }
-                TensorBlock<uint8_t> under_test(block_size, alphabet_sz, sketch_dimension,
-                                                tuple_len, /*seed=*/31415);
+                TensorBlock<uint8_t> under_test(alphabet_sz, sketch_dimension, tuple_len,
+                                                block_size, /*seed=*/31415);
                 std::vector<double> sketch = under_test.compute(sequence);
 
                 ASSERT_EQ(sketch.size(), sketch_dimension);
@@ -210,7 +211,7 @@ TEST(TensorBlock, SameAsTensorSketchForBlockSizeOne) {
         std::vector<uint8_t> sequence(std::uniform_int_distribution<uint8_t>(0, 100)(gen));
         std::generate(sequence.begin(), sequence.end(), [&]() { return rand_char(gen); });
         for (uint32_t sketch_dimension = 3; sketch_dimension < 10; ++sketch_dimension) {
-            TensorBlock<uint8_t> block(1, alphabet_sz, sketch_dimension, tuple_len, /*seed=*/31415);
+            TensorBlock<uint8_t> block(alphabet_sz, sketch_dimension, tuple_len, 1, /*seed=*/31415);
             Tensor<uint8_t> sketch(alphabet_sz, sketch_dimension, tuple_len, /*seed=*/31415);
 
             std::vector<double> sketch1 = block.compute(sequence);

--- a/tests/sketch/test_tensor_block.cpp
+++ b/tests/sketch/test_tensor_block.cpp
@@ -1,0 +1,224 @@
+#include "sketch/tensor.hpp"
+#include "sketch/tensor_block.hpp"
+
+#include "util/utils.hpp"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace {
+
+using namespace ts;
+using namespace ::testing;
+
+constexpr uint8_t alphabet_size = 4;
+const uint32_t set_size = int_pow<uint32_t>(alphabet_size, 3); // k-mers of length 3
+constexpr uint32_t sketch_dim = 2;
+constexpr uint32_t tuple_length = 3;
+
+template <typename set_type>
+void rand_init(uint32_t sketch_size, Vec2D<set_type> *hashes, Vec2D<bool> *signs) {
+    std::mt19937 gen(3412343);
+    std::uniform_int_distribution<set_type> rand_hash2(0, sketch_size - 1);
+    std::uniform_int_distribution<set_type> rand_bool(0, 1);
+
+    for (size_t h = 0; h < hashes->size(); h++) {
+        for (size_t c = 0; c < alphabet_size; c++) {
+            (*hashes)[h][c] = rand_hash2(gen);
+            (*signs)[h][c] = rand_bool(gen);
+        }
+    }
+}
+
+TEST(TensorBlock, Empty) {
+    TensorBlock<uint8_t> under_test(1, alphabet_size, sketch_dim, tuple_length, /*seed=*/31415);
+    std::vector<double> sketch = under_test.compute(std::vector<uint8_t>());
+    ASSERT_EQ(sketch.size(), sketch_dim);
+    ASSERT_THAT(sketch, ElementsAre(0, 0));
+}
+
+/** The sequence has one char, which is shorter than the tuple length, so the sketch will be 0 */
+TEST(TensorBlock, OneChar) {
+    TensorBlock<uint8_t> under_test(1, alphabet_size, sketch_dim, tuple_length, /*seed=*/31415);
+    for (uint8_t c = 0; c < alphabet_size; ++c) {
+        std::vector<double> sketch = under_test.compute({ c });
+        ASSERT_THAT(sketch, ElementsAre(0, 0));
+    }
+}
+
+/** The sequence has one char, the tuple length is 1, so we should have a value of s(seq[0]) on
+ * position h(seq[0]) */
+TEST(TensorBlock, OneCharTuple1) {
+    constexpr uint32_t tuple_len = 1;
+    TensorBlock<uint8_t> under_test(1, alphabet_size, sketch_dim, tuple_len, /*seed=*/31415);
+
+    Vec2D<uint8_t> hashes = new2D<uint8_t>(tuple_len, alphabet_size);
+    Vec2D<bool> signs = new2D<bool>(tuple_len, alphabet_size);
+    rand_init(sketch_dim, &hashes, &signs);
+    under_test.set_hashes_for_testing(hashes, signs);
+
+    for (uint8_t c = 0; c < alphabet_size; ++c) {
+        std::vector<double> sketch = under_test.compute({ c });
+        for (uint32_t i = 0; i < sketch_dim; ++i) {
+            int8_t sign = signs[0][c] ? 1 : -1;
+            ASSERT_EQ(sketch[i] * sign, hashes[0][c] % sketch_dim == i) << "Char: " << (int)c;
+        }
+    }
+}
+
+/**
+ * The size of the sequence equals the size of the tuple, so the sketch will be 1 or -1 in one
+ * position (position H(x)), and 0 in all the other positions, no matter what the block size is.
+ */
+TEST(TensorBlock, FullStringRandomChars) {
+    std::mt19937 gen(1234567);
+    for (uint32_t sketch_dimension = 3; sketch_dimension < 10; ++sketch_dimension) {
+        for (uint32_t tuple_len = 1; tuple_len < 10; ++tuple_len) {
+            for (uint32_t block_size = 1; block_size < sqrt(tuple_len); ++block_size) {
+                if (tuple_len % block_size != 0) {
+                    continue;
+                }
+                std::uniform_int_distribution<uint8_t> rand_char(0, alphabet_size - 1);
+                TensorBlock<uint8_t> under_test(block_size, alphabet_size, sketch_dimension, tuple_len,
+                                                /*seed=*/31415);
+
+                Vec2D<uint8_t> hashes = new2D<uint8_t>(tuple_len, alphabet_size);
+                Vec2D<bool> signs = new2D<bool>(tuple_len, alphabet_size);
+                rand_init(sketch_dim, &hashes, &signs);
+                under_test.set_hashes_for_testing(hashes, signs);
+
+                std::vector<uint8_t> sequence(tuple_len);
+                for (uint8_t &c : sequence) {
+                    c = rand_char(gen);
+                }
+                std::vector<double> sketch = under_test.compute(sequence);
+
+                uint32_t pos = 0; // the position where the sketch must be one
+                int8_t s = 1; // the sign of the sketch
+                for (uint32_t i = 0; i < sequence.size(); ++i) {
+                    pos += hashes[i][sequence[i]];
+                    s *= signs[i][sequence[i]] ? 1 : -1;
+                }
+                pos %= sketch_dimension;
+
+                ASSERT_EQ(sketch.size(), sketch_dimension);
+                for (uint32_t i = 0; i < sketch_dimension; ++i) {
+                    ASSERT_EQ(i == pos ? s : 0, sketch[i])
+                            << "t=" << tuple_len << " k=" << block_size << " i=" << i;
+                }
+            }
+        }
+    }
+}
+
+/**
+ * If a sequence contains identical characters, its sketch will be +/-1 in one position and 0 in all
+ * others, no matter what the block size, because all subsequences of length t are identical.
+ */
+TEST(TensorBlock, SameChars) {
+    std::mt19937 gen(342111);
+    std::uniform_int_distribution<uint8_t> rand_char(0, alphabet_size - 1);
+    std::uniform_int_distribution<uint8_t> rand_seq_len(0, 100);
+    for (uint32_t sketch_dimension = 3; sketch_dimension < 10; ++sketch_dimension) {
+        for (uint32_t tuple_len = 2; tuple_len < 10; ++tuple_len) {
+            for (uint32_t block_size = 1; block_size < sqrt(tuple_len); ++block_size) {
+                if (tuple_len % block_size != 0) {
+                    continue;
+                }
+                TensorBlock<uint8_t> under_test(block_size, tuple_len, sketch_dimension, tuple_len,
+                                                /*seed=*/127383);
+                uint8_t sequence_length = tuple_len + rand_seq_len(gen);
+                std::vector<uint8_t> sequence(sequence_length, rand_char(gen));
+                std::vector<double> sketch = under_test.compute(sequence);
+                ASSERT_EQ(sketch.size(), sketch_dimension);
+                for (uint32_t i = 0; i < sketch_dimension; ++i) {
+                    ASSERT_TRUE(std::abs(sketch[i]) == 0 || std::abs(sketch[i]) == 1)
+                            << "Dim=" << sketch_dimension << " t=" << tuple_len
+                            << " block=" << block_size;
+                }
+                ASSERT_EQ(1, std::abs(std::accumulate(sketch.begin(), sketch.end(), 0)));
+            }
+        }
+    }
+}
+
+/**
+ * If a sequence contains distinct characters, then the tensor sketch for t=1 will contain multiples
+ * of (1/alphabet_size), because T(a)=1/alphabet_size for all characters a.
+ */
+TEST(TensorBlock, DistinctCharsTuple1) {
+    std::mt19937 gen(321567);
+    constexpr uint8_t tuple_len = 1;
+    std::vector<uint8_t> sequence(alphabet_size);
+    std::iota(sequence.begin(), sequence.end(), 0);
+    for (uint32_t sketch_dimension = 3; sketch_dimension < 10; ++sketch_dimension) {
+        TensorBlock<uint8_t> under_test(1, alphabet_size, sketch_dimension, tuple_len,
+                                        /*seed=*/31415);
+
+        std::vector<double> sketch = under_test.compute(sequence);
+        ASSERT_EQ(sketch.size(), sketch_dimension);
+        for (uint32_t i = 0; i < sketch_dimension; ++i) {
+            double factor = sketch[i] / (1. / alphabet_size);
+            ASSERT_NEAR(0, std::round(factor) - factor, 1e-3);
+        }
+    }
+}
+
+/**
+ * If a sequence of length seq_len contains distinct characters, then the tensor sketch for
+ * t=seq_len-1 and block_size k will contain multiples of k/(t+k), because T(a)=k/(t+k) for
+ * all the t/k + 1 subsequences of length t formed out of blocks of size (k denotes the block size).
+ */
+TEST(TensorBlock, DistinctCharsTupleTMinus1) {
+    std::mt19937 gen(321567);
+    for (uint32_t tuple_len = 1; tuple_len < 10; ++tuple_len) {
+        const uint8_t alphabet_sz = tuple_len + 1;
+        std::vector<uint8_t> sequence(alphabet_sz);
+        std::iota(sequence.begin(), sequence.end(), 0);
+        for (uint32_t sketch_dimension = 3; sketch_dimension < 10; ++sketch_dimension) {
+            for (uint32_t block_size = 1; block_size < sqrt(tuple_len); ++block_size) {
+                if (tuple_len % block_size != 0) {
+                    continue;
+                }
+                TensorBlock<uint8_t> under_test(block_size, alphabet_sz, sketch_dimension,
+                                                tuple_len, /*seed=*/31415);
+                std::vector<double> sketch = under_test.compute(sequence);
+
+                ASSERT_EQ(sketch.size(), sketch_dimension);
+                for (uint32_t i = 0; i < sketch_dimension; ++i) {
+                    double factor = sketch[i]
+                            / (static_cast<double>(block_size) / (block_size + tuple_len));
+                    ASSERT_NEAR(factor, std::round(factor), 1e-3)
+                            << tuple_len << " " << sketch_dimension << " " << i << " "
+                            << block_size;
+                }
+            }
+        }
+    }
+}
+
+/**
+ * For a block size of 1, TensorBlock and Tensor should return identical results.
+ */
+TEST(TensorBlock, SameAsTensorSketchForBlockSizeOne) {
+    std::mt19937 gen(321567);
+    std::uniform_int_distribution<uint8_t> rand_sigma(3, 20);
+    for (uint32_t tuple_len = 1; tuple_len < 10; ++tuple_len) {
+        const uint8_t alphabet_sz = rand_sigma(gen);
+        std::uniform_int_distribution<uint8_t> rand_char(0, alphabet_sz - 1);
+
+        std::vector<uint8_t> sequence(std::uniform_int_distribution<uint8_t>(0, 100)(gen));
+        std::generate(sequence.begin(), sequence.end(), [&]() { return rand_char(gen); });
+        for (uint32_t sketch_dimension = 3; sketch_dimension < 10; ++sketch_dimension) {
+            TensorBlock<uint8_t> block(1, alphabet_sz, sketch_dimension, tuple_len, /*seed=*/31415);
+            Tensor<uint8_t> sketch(alphabet_sz, sketch_dimension, tuple_len, /*seed=*/31415);
+
+            std::vector<double> sketch1 = block.compute(sequence);
+            std::vector<double> sketch2 = sketch.compute(sequence);
+
+            ASSERT_THAT(sketch1, ElementsAreArray(sketch2));
+        }
+    }
+}
+
+} // namespace


### PR DESCRIPTION
This is just a first implementation, where I aimed for correctness rather than efficiency. 

The results look encouraging, TensorBlock seems to perform on par with the *MH even for lower mutation rates, but more testing (ideally not done by me, as I am biased) is needed to confirm.

Although strictly speaking TensorBlock is a generalization of TensorSketch (when block_size is 1), I preferred to keep the old implementation, because it's likely more efficient.