### PR TITLE
Reduce memory usage for TSB

### DIFF
--- a/sketch/tensor_block.hpp
+++ b/sketch/tensor_block.hpp
@@ -7,7 +7,6 @@
 #include "util/timer.hpp"
 #include "util/utils.hpp"
 
-#include <bits/stdint-uintn.h>
 #include <cassert>
 #include <cmath>
 #include <deque>


### PR DESCRIPTION
The DP-index that tracks the length of the t-mer so far will always be divisible by the block size `m`, since we always add `m` consecutive chars at a time. Hence, this index can have size `t/m` instead of size `t`.

This reduces the overall memory usage to be the same as normal TS again.